### PR TITLE
fix: 修复 Xcode 添加依赖失败的问题

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,6 @@ let package = Package(
         .target(
             name: "JXPagingView",
             path: "Sources/JXPagingView"),
-
         ],
-    swiftLanguageVersions: [.version("5"), .version["4.2"]]
+    swiftLanguageVersions: [.v5, .v4_2]
 )


### PR DESCRIPTION
#365 

就是 `Package.swift` 文件多了一个换行，并且 `swiftLanguageVersions` 格式需要更新一下。

问题解决～

实测 `Xcode Version 12.5.1 (12E507)` 中可以正常添加本依赖库