### PR TITLE
Modify the access permissions of the currentList property

### DIFF
--- a/Sources/JXPagingView/JXPagingView.swift
+++ b/Sources/JXPagingView/JXPagingView.swift
@@ -92,7 +92,7 @@ open class JXPagingView: UIView {
     public var automaticallyDisplayListVerticalScrollIndicator = true
     /// 当allowsCacheList为true时，请务必实现代理方法`func pagingView(_ pagingView: JXPagingView, listIdentifierAtIndex index: Int) -> String`
     public var allowsCacheList: Bool = false
-    internal var currentScrollingListView: UIScrollView?
+    public private(set) var currentScrollingListView: UIScrollView?
     internal var currentList: JXPagingViewListViewDelegate?
     private var currentIndex: Int = 0
     private weak var delegate: JXPagingViewDelegate?


### PR DESCRIPTION
At some point, the caller may need to use the current scrolling list. Therefore, exposing this property to the developers may make it easier for them to achieve what they want.