### PR TITLE
修复了JXPagerSmoothView调用了reloadData后会有空的header，导致header无法点击的bug

### DIFF
--- a/Sources/JXPagerView/JXPagerSmoothView.m
+++ b/Sources/JXPagerView/JXPagerSmoothView.m
@@ -105,7 +105,9 @@ static NSString *JXPagerSmoothViewCollectionViewCellIdentifier = @"cell";
     self.currentIndex = self.defaultSelectedIndex;
     self.currentPagerHeaderContainerViewY = 0;
     self.syncListContentOffsetEnabled = NO;
-
+    for (UIView *view in self.listHeaderDict.allValues){
+        [view removeFromSuperview];
+    }
     [self.listHeaderDict removeAllObjects];
     for (id<JXPagerSmoothViewListViewDelegate> list in self.listDict.allValues) {
         [[list listScrollView] removeObserver:self forKeyPath:@"contentOffset"];


### PR DESCRIPTION
<img width="406" alt="image" src="https://user-images.githubusercontent.com/17515825/176819959-2e52eacf-dd24-41bc-b709-46f7e0e46625.png">
